### PR TITLE
Setting up prototype screens for Match

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -16,7 +16,7 @@
 }
 
 .govuk-width-container, .moj-primary-navigation__container, .moj-header__container, .key-details-bar .key-details-bar__key-details {
-    max-width: 1220px;
+    max-width: 1000px;
     margin: 0 15px;
 }
 
@@ -647,4 +647,28 @@ $low-score-colour__text: #485b10;
       color: #d13118;
       background-color: #fff;
   }
+}
+
+key-details-bar {
+  background-color: #1d70b8;
+}
+.key-details-bar .govuk-body, .key-details-bar .govuk-body-l {
+  color: #fff;
+}
+.key-details-bar span {
+  white-space: nowrap;
+}
+.key-details-bar .key-details-bar__key-details {
+  padding: 20px 0;
+  position: relative;
+}
+.key-details-bar .key-details-bar__key-details .key-details-bar__name {
+  line-height: 1.04167;
+  line-height: 1.11111;
+  margin-inline-start: 0;
+  margin-right: 10px;
+}
+.key-details-bar .key-details-bar__key-details .key-details-bar__bottom-block {
+  margin-top: 6px;
+  padding-top: 10px;
 }

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -1,93 +1,77 @@
 {% extends "layouts/main.html" %}
+{% set containerClasses = "moj-special-width-container" %}
 
-{% set pageName="Home" %}
+{% block pageTitle %}
+Digital Prison Services - {{ serviceName }} - GOV.UK Prototype Kit
+{% endblock %}
+
 
 {% block content %}
+<div class="moj-width-container">
+    <h1 class="govuk-heading-l">Accredited Programmes in Community</h1>
+    <p class="govuk-body-l"> A prototype for Accredited Programmes within the community setting</p>
+</div>
+<div class="homepage-content">
+    <div class="moj-width-container">
+        <ul class="govuk-grid-row card-group">
+            <li class="govuk-grid-column-one-third card-group__item">
+                <div class="card card--clickable">
+                    <h2 class="govuk-heading-m card__heading">
+                        <a class="govuk-link card__link govuk-link--no-visited-state" href="/find/v1/find-design-history.html">Find a programme</a>
+                    </h2>
+                    <p class="govuk-body card__description">Search for an Accredited Programme and make a referral.</p>
+                    <p>&nbsp;</p>
+                </div>
+            </li>
+            <li class="govuk-grid-column-one-third card-group__item">
+                <div class="card card--clickable">
+                    <h2 class="govuk-heading-m card__heading">
+                        <a class="govuk-link card__link govuk-link--no-visited-state" href="#">Make a referral</a>
+                    </h2>
+                    <p class="govuk-body card__description">Look at your caseload and the status of referrals.</p>
+                    <p>&nbsp;</p>
+                </div>
+            </li>
+			<li class="govuk-grid-column-one-third card-group__item">
+                <div class="card card--clickable">
+                    <h2 class="govuk-heading-m card__heading">
+                        <a class="govuk-link card__link govuk-link--no-visited-state" href="#">Assess a person</a>
+                    </h2>
+                    <p class="govuk-body card__description">Find Accredited Programmes, make referrals and view progress of  referrals.</p>
+                    <p>&nbsp;</p>
+                </div>
+            </li>
+            <li class="govuk-grid-column-one-third card-group__item">
+                <div class="card card--clickable">
+                    <h2 class="govuk-heading-m card__heading">
+                        <a class="govuk-link card__link govuk-link--no-visited-state" href="/match/v1/match-design-history.html">Match a person</a>
+                    </h2>
+                    <p class="govuk-body card__description">Create and manage programme groups.</p>
+                    <p>&nbsp;</p>
+                </div>
+            </li>
+            <li class="govuk-grid-column-one-third card-group__item">
+                <div class="card card--clickable">
+                    <h2 class="govuk-heading-m card__heading">
+                        <a class="govuk-link card__link govuk-link--no-visited-state" href="#">Deliver a programme</a>
+                    </h2>
+                    <p class="govuk-body card__description">Example</p>
+                    <p>&nbsp;</p>
+                </div>
+            </li>
+			<li class="govuk-grid-column-one-third card-group__item">
+                <div class="card card--clickable">
+                    <h2 class="govuk-heading-m card__heading">
+                        <a class="govuk-link card__link govuk-link--no-visited-state" href="#">Monitor</a>
+                    </h2>
+                    <p class="govuk-body card__description">Add example content in here. Add example content in here. </p>
+					<p>&nbsp;</p>
+                </div>
+            </li>
+        </ul>
 
-<div class="govuk-width-container">
+       
 
-	<main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
-	  <div class="govuk-grid-row">
-	  <div class="govuk-grid-column-full">
-  
-		<h1 class="govuk-heading-l"> 
-		  Accredited Programmes in Community
-		</h1>
-  
-		<p class="govuk-body-l"> A prototype for Accredited Programmes within the community setting</p>
-            
-
-
-			 
-
-			</div>
-					</main>
-  
-	  
-	  </div>
-	  </div>
-  
-	  <div class="homepage-content">
-		<div class="moj-width-container">
-			<ul class="govuk-grid-row card-group govuk-!-margin-bottom-9">
-				<li class="govuk-grid-column-one-third card-group__item">
-					<div class="card card--clickable">
-						<h2 class="govuk-heading-m card__heading">
-							<a class="govuk-link card__link govuk-link--no-visited-state" href="/find/v1/find-design-history.html">Find a programme</a>
-						</h2>
-						<p class="govuk-body card__description">Search for an Accredited Programme and make a referral.</p>
-						<p>&nbsp;</p>
-					</div>
-				</li>
-				<li class="govuk-grid-column-one-third card-group__item">
-					<div class="card card--clickable">
-						<h2 class="govuk-heading-m card__heading">
-							<a class="govuk-link card__link govuk-link--no-visited-state" href="#">Make a referral</a>
-						</h2>
-						<p class="govuk-body card__description">Look at your caseload and the status of referrals.</p>
-					</div>
-				</li>
-				<li class="govuk-grid-column-one-third card-group__item">
-					<div class="card card--clickable">
-						<h2 class="govuk-heading-m card__heading">
-							<a class="govuk-link card__link govuk-link--no-visited-state" href="#">Assess a person</a>
-						</h2>
-						<p class="govuk-body card__description">Look at your caseload and the status of referrals.</p>
-					</div>
-				</li>
-				<li class="govuk-grid-column-one-third card-group__item">
-					<div class="card card--clickable">
-						<h2 class="govuk-heading-m card__heading">
-							<a class="govuk-link card__link govuk-link--no-visited-state" href="#">Match a person</a>
-						</h2>
-						<p class="govuk-body card__description">Look at your caseload and the status of referrals.</p>
-					</div>
-				</li>
-				<li class="govuk-grid-column-one-third card-group__item">
-					<div class="card card--clickable">
-						<h2 class="govuk-heading-m card__heading">
-							<a class="govuk-link card__link govuk-link--no-visited-state" href="#">Deliver a programme</a>
-						</h2>
-						<p class="govuk-body card__description">Look at your caseload and the status of referrals.</p>
-					</div>
-				</li>
-				<li class="govuk-grid-column-one-third card-group__item">
-					<div class="card card--clickable">
-						<h2 class="govuk-heading-m card__heading">
-							<a class="govuk-link card__link govuk-link--no-visited-state" href="#">Monitor</a>
-						</h2>
-						<p class="govuk-body card__description">Look at your caseload and the status of referrals.</p>
-					</div>
-				</li>
-			</ul>
-			<div class="faux-div govuk-!-margin-bottom-9">&nbsp;</div>
-			<div class="faux-div govuk-!-margin-bottom-9">&nbsp;</div>
-			<div class="faux-div govuk-!-margin-bottom-9">&nbsp;</div>
-			<div class="faux-div govuk-!-margin-bottom-9">&nbsp;</div>
-			<div class="faux-div govuk-!-margin-bottom-9">&nbsp;</div>
-			<div class="faux-div govuk-!-margin-bottom-9">&nbsp;</div>
-		</div>
-	</div>
-  </div>
-
+    </div>
+</div>
 {% endblock %}

--- a/app/views/layouts/main.html
+++ b/app/views/layouts/main.html
@@ -13,7 +13,7 @@ https://prototype-kit.service.gov.uk/docs/how-to-use-layouts
   serviceUrl: "#",
   navigation: [
     {
-      href: "/find/v2/find-design-history.html",
+      href: "find/v1/find-design-history.html",
       text: "Find"
     },
     {
@@ -25,7 +25,7 @@ https://prototype-kit.service.gov.uk/docs/how-to-use-layouts
       text: "Assess"
     },
     {
-        href: "#4",
+        href: "/match/v1/match-design-history.html",
         text: "Match"
       },
       {

--- a/app/views/layouts/main.html
+++ b/app/views/layouts/main.html
@@ -5,7 +5,6 @@ https://prototype-kit.service.gov.uk/docs/how-to-use-layouts
 
 {% extends "govuk-prototype-kit/layouts/govuk-branded.njk" %}
 
-
 {% block header %}
 {{ govukHeader({
   homepageUrl: "/index.html",
@@ -34,4 +33,5 @@ https://prototype-kit.service.gov.uk/docs/how-to-use-layouts
       }
   ]
 }) }}
+
 {% endblock %}

--- a/app/views/match/v1/create-group/capacity.html
+++ b/app/views/match/v1/create-group/capacity.html
@@ -1,0 +1,43 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+  Home – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "/task-list-standard"
+  }) }}
+{% endblock %}
+
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <form action="/release-date-answer" method="post" novalidate>
+
+      <div class="govuk-form-group">
+        <span class="govuk-caption-l">Create a group</span>
+        <h1 class="govuk-label-wrapper">
+          <label class="govuk-label govuk-label--l" for="event-name">
+            How many people can be allocated to this group?
+          </label>
+        </h1>
+        <p class="govuk-body">Enter the maximum number (known as capacity) of people who can be allocated.
+        </p>
+        <input class="govuk-input govuk-input--width-3" id="width-3" name="width3" type="text">
+      </div>
+      <button type="submit" class="govuk-button" data-module="govuk-button">
+        Save and continue
+      </button>
+
+    </form>
+
+  </div>
+</div>
+
+
+
+{% endblock %}

--- a/app/views/match/v1/create-group/create-group-name.html
+++ b/app/views/match/v1/create-group/create-group-name.html
@@ -1,0 +1,48 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Home" %}
+
+{% block content %}
+
+<div class="govuk-width-container">
+
+	<main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+	  <div class="govuk-grid-row">
+	  <div class="govuk-grid-column-full">
+  
+	  <!-- Header -->
+		  <div class="govuk-grid-row">
+			<div class="govuk-grid-column-two-thirds">
+				<span class="govuk-caption-l">BBR/LEEDS/08/EVE/THURS/060723</span>
+				<h1 class="govuk-heading-xl govuk-!-margin-bottom-7">
+					Building better relationships
+				</h1>
+		
+				
+				<p class="govuk-body">Capacity: 15
+				</p>
+				<p class="govuk-body">Allocated: 15</p>
+				<p class="govuk-body">Waitlist: 4</p>
+		
+			</div>
+		
+			<div class="govuk-grid-column-one-third">
+				<h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+					Related tasks
+				</h2>
+				<ul class="govuk-list">
+					<li>
+						<a href="">
+							Create a group
+						</a>
+					</li>
+
+				</ul>
+			</div>
+		</div>
+    
+  
+	</main>
+  </div>
+
+{% endblock %}

--- a/app/views/match/v1/create-group/start-date.html
+++ b/app/views/match/v1/create-group/start-date.html
@@ -1,0 +1,91 @@
+{% extends "layouts/main.html" %}
+
+{% block pageTitle %}
+  Home – GOV.UK Prototype Kit
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "/task-list-standard"
+  }) }}
+{% endblock %}
+
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <form action="/release-date-answer" method="post" novalidate>
+
+      {% set dateHtml %}
+      {{ govukInput({
+        id: "date-of-release",
+        name: "date-of-release",
+        type: "date",
+        classes: "govuk-!-width-one-half",
+        label: {
+          text: "Expected date of release"
+        }
+      }) }}
+      {% endset -%}
+
+      {% set html %}
+      <p>
+        You can still submit your application.
+      </p>
+      <p>
+        An assessor will make a decision on suitability for an Approved Premises placement.
+      </p>
+      <p>If your application is suitable, you will need to request a placement as soon as you know the release date.</p>
+      {% endset %}
+
+      {% set noReleaseDate %}
+      {{ govukNotificationBanner({
+        html: html
+      }) }}
+      {% endset -%}
+
+
+      {{ govukRadios({
+        id: "release-date",
+        name: "release-date",
+        fieldset: {
+          legend: {
+            text: "Do you know the person's release date?",
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--l"
+          }
+        },
+        items: [
+          {
+            value: "release-date-known",
+            text: "Yes",
+            conditional: {
+              html: dateHtml
+            }
+          },
+          {
+            value: "release-date-unknown",
+            text: "No, the release date is to be determined by the parole board or other hearing",
+            conditional: {
+              html: noReleaseDate
+            }
+          }
+        ]
+      }) }}
+
+      <input type="hidden" name="answers-checked" value="true">
+
+      <button type="submit" class="govuk-button" data-module="govuk-button">
+        Save and continue
+      </button>
+
+    </form>
+
+  </div>
+</div>
+
+
+
+{% endblock %}

--- a/app/views/match/v1/group-information.html
+++ b/app/views/match/v1/group-information.html
@@ -1,0 +1,707 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Home" %}
+
+{% block beforeContent %}
+  
+	{{ govukBackLink({
+		text: "Back",
+		href: "/match/v1/group-list"
+	}) }}
+	
+{% endblock %}
+
+
+{% block content %}
+
+<div class="govuk-width-container">
+	  <!-- Header -->
+		  <div class="govuk-grid-row">
+			<div class="govuk-grid-column-two-thirds">
+				<span class="govuk-caption-l">BBR/LEEDS/08/EVE/THURS/060723</span>
+				<h1 class="govuk-heading-xl govuk-!-margin-bottom-7">
+					Building better relationships
+				</h1>
+		
+				
+				<p class="govuk-body">Capacity: 15</p>
+				<p class="govuk-body">Allocated: 15</p>
+				<p class="govuk-body">Waitlist: 4</p>
+		
+
+				<details class="govuk-details">
+					<summary class="govuk-details__summary">
+					  <span class="govuk-details__summary-text">
+						Check the requirements for this programme
+					  </span>
+					</summary>
+					<div class="govuk-details__text">
+						<dl class="govuk-summary-list govuk-summary-list--no-borderr">
+							<div class="govuk-summary-list__row govuk-summary-list__row--no-actions">
+							  <dt class="govuk-summary-list__key">
+								Suitable for workplace risk assessment
+							  </dt>
+							  <dd class="govuk-summary-list__value">
+								Low, Medium or High		
+							 </dd>  
+							</div>
+							<div class="govuk-summary-list__row">
+							  <dt class="govuk-summary-list__key">
+								Suitable for incentive level
+							  </dt>
+							  <dd class="govuk-summary-list__value">
+								<p>Basic, Standard or Enhanced</p>
+												<p class="govuk-hint">
+													You can control which incentive levels are suitable by <a href="edit/pay-rates">adding or
+														removing corresponding pay rates</a>.
+												</p>
+							  </dd>
+							  
+							</div>
+							<div class="govuk-summary-list__row">
+							  <dt class="govuk-summary-list__key">
+								Education level
+							  </dt>
+							  <dd class="govuk-summary-list__value">
+								English level 1
+							  </dd>
+							  
+							</div>
+					  </dl></div>
+				  </details>
+			</div>
+
+		<div class="govuk-grid-column-one-third">
+			<h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+					Related tasks
+				</h2>
+				<ul class="govuk-list">
+					<li>
+						<a href="/create-group-name.html" class="govuk-link">
+							Add a person to this group
+						</a>
+					</li>
+
+				</ul>
+			</div>
+		
+
+		</div>
+  
+
+	
+
+		  
+	 <!-- Tabs -->
+
+		  <div class="govuk-tabs" data-module="govuk-tabs">
+			<h2 class="govuk-tabs__title">
+			  Contents
+			</h2>
+			<ul class="govuk-tabs__list">
+			  <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+				<a class="govuk-tabs__tab" href="#past-day">
+				  Currently allocated
+				</a>
+			  </li>
+			  <li class="govuk-tabs__list-item">
+				<a class="govuk-tabs__tab" href="#past-week">
+				  Waitlist
+				</a>
+			  </li>
+			  <li class="govuk-tabs__list-item">
+				<a class="govuk-tabs__tab" href="#past-month">
+				  Allocate a person
+				</a>
+			  </li>
+			</ul>
+			
+			<div class="govuk-tabs__panel" id="past-day">
+                    <h2 class="govuk-heading-l govuk-!-margin-bottom-5">
+                        12 people currently allocated
+                    </h2>
+
+                    <div class="govuk-button-group govuk-!-margin-bottom-5">
+                        <!-- <a href="deallocate" class="govuk-link" style="color: #be0e0e;">
+                            Remove people from this activity
+                        </a> -->
+                    </div>
+
+                    <table class="govuk-table govuk-!-margin-bottom-5" data-module="moj-multi-select" data-multi-select-checkbox="#select-all">
+                        <thead class="govuk-table__head">
+                            <tr class="govuk-table__row">
+                                <th class="govuk-table__header govuk-!-padding-right-2 govuk-!-padding-left-1" scope="col" id="select-all"></th>
+                                <th scope="col" class="govuk-table__header">Name</th>
+                                <th scope="col" class="govuk-table__header">CRN</th>
+                                <th scope="col" class="govuk-table__header">Allocation start and end</th>
+                                <th scope="col" class="govuk-table__header">Other allocations</th>
+                                <th scope="col" class="govuk-table__header">Earliest release date</th>
+                                <th scope="col" class="govuk-table__header"></th>
+                            </tr>
+                        </thead>
+                        <tbody class="govuk-table__body">
+                            
+                            <tr class="govuk-table__row">
+                                <td class="govuk-table__cell">
+                                    <div class="govuk-checkboxes__item govuk-checkboxes--small moj-multi-select__checkbox govuk-!-margin-right-2 govuk-!-margin-left-1">
+                                        <input type="checkbox" class="govuk-checkboxes__input" id="prisoner-1" name="selected-prisoners" value="AP9029D">
+                                        <label class="govuk-label govuk-checkboxes__label" for="prisoner-1">
+                                            <span class="govuk-visually-hidden">Select Capper,
+                                                Nicol</span>
+                                        </label>
+                                    </div>
+                                </td>
+                                <td class="govuk-table__cell">
+                                    <b>
+                                        <a href="person-dashboard/person-dashboard.html" class="govuk-link--no-visited-state">
+                                            Capper, Nicol
+                                        </a>
+                                    </b>
+                                    <br>
+                                    AP9029D
+                                    <br>
+                                    1−1−8
+                                </td>
+                                <td class="govuk-table__cell">
+                                    
+                                    None
+                                    
+                                </td>
+                                <td class="govuk-table__cell">
+                                    14 May 2023
+                                    
+                                    <br>
+                                    to
+                                    15 Mar 2025
+                                    
+                                </td>
+                                <td class="govuk-table__cell">
+                                    
+                                    <span class="govuk-hint">None</span>
+                                    
+                                </td>
+                                <td class="govuk-table__cell">
+                                    15 Feb 2028
+                                </td>
+                            </tr>
+                            
+                            <tr class="govuk-table__row">
+                                <td class="govuk-table__cell">
+                                    <div class="govuk-checkboxes__item govuk-checkboxes--small moj-multi-select__checkbox govuk-!-margin-right-2 govuk-!-margin-left-1">
+                                        <input type="checkbox" class="govuk-checkboxes__input" id="prisoner-2" name="selected-prisoners" value="ZG2176A">
+                                        <label class="govuk-label govuk-checkboxes__label" for="prisoner-2">
+                                            <span class="govuk-visually-hidden">Select Castellani,
+                                                Bartie</span>
+                                        </label>
+                                    </div>
+                                </td>
+                                <td class="govuk-table__cell">
+                                    <b>
+                                        <a href="#" class="govuk-link--no-visited-state">
+                                            Castellani, Bartie
+                                        </a>
+                                    </b>
+                                    <br>
+                                    ZG2176A
+                                    <br>
+                                    1−1−2
+                                </td>
+                                <td class="govuk-table__cell">
+                                    
+                                    None
+                                    
+                                </td>
+                                <td class="govuk-table__cell">
+                                    3 Mar 2023
+                                    
+                                </td>
+                                <td class="govuk-table__cell">
+                                    
+                                    <span class="govuk-hint">None</span>
+                                    
+                                </td>
+                                <td class="govuk-table__cell">
+                                    27 Sept 2035
+                                </td>
+                            </tr>
+                            
+                            <tr class="govuk-table__row">
+                                <td class="govuk-table__cell">
+                                    <div class="govuk-checkboxes__item govuk-checkboxes--small moj-multi-select__checkbox govuk-!-margin-right-2 govuk-!-margin-left-1">
+                                        <input type="checkbox" class="govuk-checkboxes__input" id="prisoner-3" name="selected-prisoners" value="XD6188J">
+                                        <label class="govuk-label govuk-checkboxes__label" for="prisoner-3">
+                                            <span class="govuk-visually-hidden">Select De Filippi,
+                                                Thornie</span>
+                                        </label>
+                                    </div>
+                                </td>
+                                <td class="govuk-table__cell">
+                                    <b>
+                                        <a href="#" class="govuk-link--no-visited-state">
+                                            De Filippi, Thornie
+                                        </a>
+                                    </b>
+                                    <br>
+                                    XD6188J
+                                    <br>
+                                    1−3−5
+                                </td>
+                                <td class="govuk-table__cell">
+                                    
+                                    <ul class="govuk-list">
+                                        <li>
+											None
+                                        </li>
+                                    </ul>
+                                    <!-- <details class="govuk-details" data-module="govuk-details">
+                                        <summary class="govuk-details__summary">
+                                            <span class="govuk-details__summary-text">
+                                                3 non associations
+                                            </span>
+                                        </summary>
+                                        <div class="govuk-details__text">
+                                            <ul class="govuk-list">
+                                                <li><a href="#" class="govuk-link--no-visited-state">Jordan Johnson-Jones</a>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                    </details> -->
+                                    
+                                </td>
+                                <td class="govuk-table__cell">
+                                    5 May 2023
+                                    
+                                </td>
+                                <td class="govuk-table__cell">
+                                    
+                                    <ul class="govuk-list">
+										None
+                                    </ul>
+                                </td>
+                                <td class="govuk-table__cell">
+                                    28 May 2031
+                                </td>
+                            </tr>
+                            
+                            <tr class="govuk-table__row">
+                                <td class="govuk-table__cell">
+                                    <div class="govuk-checkboxes__item govuk-checkboxes--small moj-multi-select__checkbox govuk-!-margin-right-2 govuk-!-margin-left-1">
+                                        <input type="checkbox" class="govuk-checkboxes__input" id="prisoner-4" name="selected-prisoners" value="IW8112X">
+                                        <label class="govuk-label govuk-checkboxes__label" for="prisoner-4">
+                                            <span class="govuk-visually-hidden">Select Flather,
+                                                Devlen</span>
+                                        </label>
+                                    </div>
+                                </td>
+                                <td class="govuk-table__cell">
+                                    <b>
+                                        <a href="#" class="govuk-link--no-visited-state">
+                                            Flather, Devlen
+                                        </a>
+                                    </b>
+                                    <br>
+                                    IW8112X
+                                    <br>
+                                    2−3−19
+                                </td>
+                                <td class="govuk-table__cell">
+                                    
+                                    None
+                                    
+                                </td>
+                                <td class="govuk-table__cell">
+                                    14 Jan 2023
+                                    
+                                </td>
+                                <td class="govuk-table__cell">
+                                    
+                                    <ul class="govuk-list">
+                                        
+                                        <!-- don't show the allocation if it's the same as the current activity -->
+                                        
+                                        
+                                        <li><a href="../7" class="govuk-link--no-visited-state">Counseling Session</a></li>
+                                        
+                                        
+                                        <!-- don't show the allocation if it's the same as the current activity -->
+                                        
+                                        
+                                        <li><a href="../54" class="govuk-link--no-visited-state">Addiction Support Group</a></li>
+                                        
+                                        
+                                    </ul>
+                                    
+                                </td>
+                                <td class="govuk-table__cell">
+                                    2 Nov 2028
+                                </td>
+                            </tr>
+
+                        </tbody>
+                    </table>
+			</div>
+			<div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="past-week">
+			  <h2 class="govuk-heading-m">Waitlist</h2>
+			  <table class="govuk-table" data-module="moj-sortable-table">
+
+				<thead class="govuk-table__head">
+				  <tr class="govuk-table__row">
+			  
+					<th scope="col" class="govuk-table__header" aria-sort="ascending">Group</th>
+			  
+					<th scope="col" class="govuk-table__header" aria-sort="none">Programme</th>
+	
+					<th scope="col" class="govuk-table__header" aria-sort="none">Start date</th>
+	
+					<th scope="col" class="govuk-table__header" aria-sort="none">End date</th>
+			  
+					<th scope="col" class="govuk-table__header" aria-sort="none">Capacity</th>
+			  
+					<th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none">Waitlist</th>
+			  
+				  </tr>
+				</thead>
+			  
+				<tbody class="govuk-table__body">
+			  
+				  <tr class="govuk-table__row">
+			  
+					<td class="govuk-table__cell">BBR/LEEDS/02/EVE/THURS/180124</td>
+			  
+					<td class="govuk-table__cell" data-sort-value="6961">
+						<strong class="govuk-tag govuk-tag--purple">
+							Building Better Relationships
+						</strong>
+					</td>
+			  
+					<td class="govuk-table__cell">14 Feb 24</td>
+			  
+					<td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="1897">14 May 24</td>
+	
+					<td class="govuk-table__cell">10</td>
+	
+					<td class="govuk-table__cell">2</td>
+			  
+				  </tr>
+			  
+				  <tr class="govuk-table__row">
+			  
+					<td class="govuk-table__cell">BBR/HUDS/01/EVE/MON/180923</td>
+			  
+					<td class="govuk-table__cell" data-sort-value="6194">
+						<strong class="govuk-tag govuk-tag--purple">
+							Building Better Relationships
+						</strong>
+					</td>
+			  
+					<td class="govuk-table__cell">24 Feb 24</td>
+			  
+					<td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="1913">26 May 24</td>
+					
+					<td class="govuk-table__cell">11</td>
+	
+					<td class="govuk-table__cell">2</td>
+			  
+				  </tr>
+			  
+				  <tr class="govuk-table__row">
+			  
+					<td class="govuk-table__cell" a href="">
+						BBR/LEEDS/08/EVE/THURS/060723
+					</td>
+			  
+					<td class="govuk-table__cell" data-sort-value="5642">
+						<strong class="govuk-tag govuk-tag--purple">
+							Building Better Relationships
+						</strong>
+					</td>
+			  
+					<td class="govuk-table__cell">16 Feb 14</td>
+			  
+					<td class="govuk-table__cell govuk-table__cell--numeric" data-sort-value="1874">16 May 24</td>
+			  
+					<td class="govuk-table__cell">15</td>
+	
+					<td class="govuk-table__cell">2</td>
+				  </tr>
+				</tbody>
+			  </table>
+			</div>
+			<div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="past-month">
+			  <h2 class="govuk-heading-l">Find a person to allocate to this group</h2>
+			  
+			  <div class="govuk-grid-row">
+				<div class="govuk-grid-column-two-thirds">
+					<div class="moj-search govuk-!-margin-top-4">
+
+						<div class="govuk-form-group">
+							<label class="govuk-label moj-search__label govuk-!-font-weight-bold" for="name">
+								Search by name or CRN
+							</label>
+							<input class="govuk-input moj-search__input " id="name" name="search" type="search" value="">
+						</div>
+						<button class="govuk-button moj-search__button" data-module="govuk-button">
+							Search
+						</button>
+					</div>
+				</div>
+			</div>
+			<table class="govuk-table govuk-!-margin-top-5" id="list">
+				<caption class="govuk-table__caption govuk-table__caption--m">
+					390 people
+					available for allocation
+				</caption>
+				<thead class="govuk-table__head">
+					<tr class="govuk-table__row">
+						<th scope="col" class="govuk-table__header" aria-sort="none">Prisoner</th>
+						<th scope="col" class="govuk-table__header" aria-sort="ascending">Non-associations</th>
+						<th scope="col" class="govuk-table__header" aria-sort="none">Current allocation</th>
+						<th scope="col" class="govuk-table__header" aria-sort="none">Education level held</th>
+						<th scope="col" class="govuk-table__header" aria-sort="none">Earliest release date</th>
+						<th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none">Other waitlists</th>
+						<th scope="col" class="govuk-table__header"></th>
+					</tr>
+				</thead>
+				<tbody class="govuk-table__body">
+					
+					<tr class="govuk-table__row">
+						<td class="govuk-table__cell">
+							<a href="../../../prisoner/GH4911Z" class="govuk-link--no-visited-state govuk-!-display-block"><b>Gori</b>,
+								Hubey</a>
+							<span class="govuk-hint govuk-!-font-size-16 govuk-!-display-block govuk-!-margin-0">GH4911Z</span>
+							<span class="govuk-hint govuk-!-font-size-16 govuk-!-display-block govuk-!-margin-0">1−1−3</span>
+						</td>
+						<td class="govuk-table__cell" data-sort-value="">
+							
+							<span class="govuk-hint">None</span>
+							
+						</td>
+						<td class="govuk-table__cell">
+							<ul class="govuk-list">
+								<!-- 
+								
+								
+								<li><a href="../23" class="govuk-link--no-visited-state">Printing Class</a></li>
+								
+								
+								<li><a href="../11" class="govuk-link--no-visited-state">English Skills Class</a></li>
+								 -->
+								<li><span class="govuk-hint">None</span></li>
+							</ul>
+						</td>
+						<td class="govuk-table__cell">
+							<ul class="govuk-list">
+								
+								<li>English level 1</li>
+								
+							</ul>
+						</td>
+						<td class="govuk-table__cell" data-sort-value="2027-04-29">
+							29 Apr 2027
+						</td>
+						<td class="govuk-table__cell" data-sort-value="2027-04-29" style="text-align: center;">
+							<ul class="govuk-list">
+								
+								<li>0</li>
+								
+							</ul>
+						</td>
+						<td class="govuk-table__cell">
+							<a href="../1/allocate/GH4911Z" class="govuk-link--no-visited-state">Allocate</a>
+						</td>
+					</tr>
+					
+					<tr class="govuk-table__row">
+						<td class="govuk-table__cell">
+							<a href="../../../prisoner/KJ6418O" class="govuk-link--no-visited-state govuk-!-display-block"><b>Alderman</b>,
+								Thatcher</a>
+							<span class="govuk-hint govuk-!-font-size-16 govuk-!-display-block govuk-!-margin-0">KJ6418O</span>
+							<span class="govuk-hint govuk-!-font-size-16 govuk-!-display-block govuk-!-margin-0">1−1−4</span>
+						</td>
+						<td class="govuk-table__cell" data-sort-value="">
+							
+							<span class="govuk-hint">None</span>
+							
+						</td>
+						<td class="govuk-table__cell">
+							<ul class="govuk-list">
+								<!-- 
+								<span class="govuk-hint">None</span>
+								
+								 -->
+								<li><span class="govuk-hint">None</span></li>
+							</ul>
+						</td>
+						<td class="govuk-table__cell">
+							<ul class="govuk-list">
+								
+								<li>English level 1</li>
+								
+							</ul>
+						</td>
+						<td class="govuk-table__cell" data-sort-value="2024-10-22">
+							22 Oct 2024
+						</td>
+						<td class="govuk-table__cell" data-sort-value="2024-10-22" style="text-align: center;">
+							<ul class="govuk-list">
+								
+								<li>0</li>
+								
+							</ul>
+						</td>
+						<td class="govuk-table__cell">
+							<a href="../1/allocate/KJ6418O" class="govuk-link--no-visited-state">Allocate</a>
+						</td>
+					</tr>
+					
+					<tr class="govuk-table__row">
+						<td class="govuk-table__cell">
+							<a href="../../../prisoner/RX5657Y" class="govuk-link--no-visited-state govuk-!-display-block"><b>Easom</b>,
+								Brant</a>
+							<span class="govuk-hint govuk-!-font-size-16 govuk-!-display-block govuk-!-margin-0">RX5657Y</span>
+							<span class="govuk-hint govuk-!-font-size-16 govuk-!-display-block govuk-!-margin-0">1−1−5</span>
+						</td>
+						<td class="govuk-table__cell" data-sort-value="">
+							
+							<span class="govuk-hint">None</span>
+							
+						</td>
+						<td class="govuk-table__cell">
+							<ul class="govuk-list">
+								<!-- 
+								
+								
+								<li><a href="../11" class="govuk-link--no-visited-state">English Skills Class</a></li>
+								 -->
+								<li><span class="govuk-hint">None</span></li>
+							</ul>
+						</td>
+						<td class="govuk-table__cell">
+							<ul class="govuk-list">
+								
+								<li><span class="govuk-hint">N/A</span></li>
+								
+							</ul>
+						</td>
+						<td class="govuk-table__cell" data-sort-value="2027-06-30">
+							30 Jun 2027
+						</td>
+						<td class="govuk-table__cell" data-sort-value="2027-06-30" style="text-align: center;">
+							<ul class="govuk-list">
+								
+								<li>1</li>
+								
+							</ul>
+						</td>
+						<td class="govuk-table__cell">
+							<a href="../1/allocate/RX5657Y" class="govuk-link--no-visited-state">Allocate</a>
+						</td>
+					</tr>
+					
+					<tr class="govuk-table__row">
+						<td class="govuk-table__cell">
+							<a href="../../../prisoner/GQ8843H" class="govuk-link--no-visited-state govuk-!-display-block"><b>Victor</b>,
+								Itch</a>
+							<span class="govuk-hint govuk-!-font-size-16 govuk-!-display-block govuk-!-margin-0">GQ8843H</span>
+							<span class="govuk-hint govuk-!-font-size-16 govuk-!-display-block govuk-!-margin-0">1−1−2</span>
+						</td>
+						<td class="govuk-table__cell" data-sort-value="">
+							
+							<a href="#" class="govuk-link--no-visited-state">Joe Bloggs</a>
+							
+						</td>
+						<td class="govuk-table__cell">
+							<ul class="govuk-list">
+								<!-- 
+								
+								
+								<li><a href="../27" class="govuk-link--no-visited-state">Small Works Team</a></li>
+								 -->
+								<li><span class="govuk-hint">None</span></li>
+							</ul>
+						</td>
+						<td class="govuk-table__cell">
+							<ul class="govuk-list">
+								
+								<li>English level 1</li>
+								
+							</ul>
+						</td>
+						<td class="govuk-table__cell" data-sort-value="2027-04-12">
+							12 Apr 2027
+						</td>
+						<td class="govuk-table__cell" data-sort-value="2027-04-12" style="text-align: center;">
+							<ul class="govuk-list">
+								
+								<li>1</li>
+								
+							</ul>
+						</td>
+						<td class="govuk-table__cell">
+							<a href="../1/allocate/GQ8843H" class="govuk-link--no-visited-state">Allocate</a>
+						</td>
+					</tr>
+					
+					<tr class="govuk-table__row">
+						<td class="govuk-table__cell">
+							<a href="../../../prisoner/OE0455U" class="govuk-link--no-visited-state govuk-!-display-block"><b>Sissel</b>,
+								Lammond</a>
+							<span class="govuk-hint govuk-!-font-size-16 govuk-!-display-block govuk-!-margin-0">OE0455U</span>
+							<span class="govuk-hint govuk-!-font-size-16 govuk-!-display-block govuk-!-margin-0">1−1−1</span>
+						</td>
+						<td class="govuk-table__cell" data-sort-value="">
+							
+							<ul class="govuk-list">
+								<li><a href="#" class="govuk-link--no-visited-state">Joe Bloggs</a></li>
+								<li><a href="#" class="govuk-link--no-visited-state">Bob Smith</a></li>
+							</ul>
+							
+						</td>
+						<td class="govuk-table__cell">
+							<ul class="govuk-list">
+								<!-- 
+								
+								
+								<li><a href="../5" class="govuk-link--no-visited-state">Christian Service</a></li>
+								
+								
+								<li><a href="../17" class="govuk-link--no-visited-state">Maths Skills Class</a></li>
+								 -->
+								<li><span class="govuk-hint">None</span></li>
+							</ul>
+						</td>
+						<td class="govuk-table__cell">
+							<ul class="govuk-list">
+								
+								<li><span class="govuk-hint">N/A</span></li>
+								
+							</ul>
+						</td>
+						<td class="govuk-table__cell" data-sort-value="2042-03-10">
+							10 Mar 2042
+						</td>
+						<td class="govuk-table__cell" data-sort-value="2042-03-10" style="text-align: center;">
+							<ul class="govuk-list">
+								
+								<li>1</li>
+								
+							</ul>
+						</td>
+						<td class="govuk-table__cell">
+							<a href="../1/allocate/OE0455U" class="govuk-link--no-visited-state">Allocate</a>
+						</td>
+					</tr>
+					
+				</tbody>
+			</table>
+			</div>
+			
+
+
+		  
+		  
+  
+	</main>
+  </div>
+
+{% endblock %}

--- a/app/views/match/v1/group-list.html
+++ b/app/views/match/v1/group-list.html
@@ -1,0 +1,168 @@
+{% extends "layouts/hmpps.html" %}
+
+{% set pageName="Home" %}
+
+
+{% block beforeContent %}
+	{{ govukBackLink({
+		text: "Back",
+		href: "/match/v1/match-design-history"
+	}) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-width-container">
+
+	<main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+	  <div class="govuk-grid-row">
+	  <div class="govuk-grid-column-full">
+  
+	  
+		  <div class="govuk-grid-row">
+			<div class="govuk-grid-column-two-thirds">
+				<!-- <span class="govuk-caption-l">Manage group</span> -->
+				<h1 class="govuk-heading-xl govuk-!-margin-bottom-7">
+					[Group name]
+				</h1>
+		
+				<p class="govuk-body-l">
+					All programme groups
+				</p>
+		
+				<!-- <p>
+					You can view or edit details for a single activity, or you can select multiple activities to pause, archive or delete them.
+				</p> -->
+		
+				<!-- <p>
+					<a href="../create-activity" class="govuk-button govuk-button--secondar">Create an activity</a>
+				</p> -->
+			</div>
+		
+			<div class="govuk-grid-column-one-third">
+				<h2 class="govuk-heading-m govuk-!-margin-bottom-2">
+					Related tasks
+				</h2>
+				<ul class="govuk-list">
+					<li>
+						<a href="/create-group/create-group-name" class="govuk-link govuk-link--no-visited-state">
+							Create a group
+						</a>
+					</li>
+				</ul>
+			</div>
+		</div>
+  
+	 
+		<nav class="moj-sub-navigation" aria-label="Sub navigation">
+
+			<ul class="moj-sub-navigation__list">
+				<li class="moj-sub-navigation__item">
+				  <a class="moj-sub-navigation__link" aria-current="page" href="all">Upcoming</a>
+				</li>
+			  
+				<li class="moj-sub-navigation__item">
+				  <a class="moj-sub-navigation__link" href="#">Current programmes</a>
+				</li>
+			  </ul>
+		  
+		  </nav>
+
+		  <table class="govuk-table" data-module="moj-sortable-table">
+
+			<thead class="govuk-table__head">
+			  <tr class="govuk-table__row">
+		  
+				<th scope="col" class="govuk-table__header" aria-sort="ascending">Group</th>
+		  
+				<th scope="col" class="govuk-table__header" width="20%" aria-sort="none">Programme</th>
+
+				<th scope="col" class="govuk-table__header" width="15%" aria-sort="none">Start date</th>
+
+				<th scope="col" class="govuk-table__header" aria-sort="none">End date</th>
+		  
+				<th scope="col" class="govuk-table__header" aria-sort="none">Capacity</th>
+		  
+				<th scope="col" class="govuk-table__header govuk-table__header--numeric" aria-sort="none">Waitlist</th>
+		  
+			  </tr>
+			</thead>
+		  
+			<tbody class="govuk-table__body">
+		  
+			  <tr class="govuk-table__row">
+		  
+				<td class="govuk-table__cell">
+					<a href="#">
+						BBR/LEEDS/02/EVE/THURS/180124
+					</a>
+				</td>
+		  
+				<td class="govuk-table__cell" data-sort-value="6961">
+					<strong class="govuk-tag govuk-tag--purple">
+						Building Better Relationships
+					</strong>
+				</td>
+		  
+				<td class="govuk-table__cell">14 Feb 24</td>
+		  
+				<td class="govuk-table__cell" data-sort-value="1897">14 May 24</td>
+
+				<td class="govuk-table__cell">10</td>
+
+				<td class="govuk-table__cell">2</td>
+		  
+			  </tr>
+		  
+			  <tr class="govuk-table__row">
+		  
+				<td class="govuk-table__cell">
+					<a href="#">
+						BBR/HUDS/01/EVE/MON/180923
+					</a>
+				</td>
+		  
+				<td class="govuk-table__cell" data-sort-value="6194">
+					<strong class="govuk-tag govuk-tag--purple">
+						Building Better Relationships
+					</strong>
+				</td>
+		  
+				<td class="govuk-table__cell">24 Feb 24</td>
+		  
+				<td class="govuk-table__cell" data-sort-value="1913">26 May 24</td>
+				
+				<td class="govuk-table__cell">11</td>
+
+				<td class="govuk-table__cell">2</td>
+		  
+			  </tr>
+		  
+			  <tr class="govuk-table__row">
+		  
+				<td class="govuk-table__cell">
+					<a href="/match/v1/group-information"> BBR/LEEDS/08/EVE/THURS/060723  </p>
+				</td>
+		  
+				<td class="govuk-table__cell" data-sort-value="5642">
+					<strong class="govuk-tag govuk-tag--purple">
+						Building Better Relationships
+					</strong>
+				</td>
+		  
+				<td class="govuk-table__cell">16 Feb 14</td>
+		  
+				<td class="govuk-table__cell" data-sort-value="1874">16 May 24</td>
+		  
+				<td class="govuk-table__cell">15</td>
+
+				<td class="govuk-table__cell">2</td>
+			  </tr>
+			</tbody>
+		  </table>
+		  
+  
+	</main>
+  </div>
+
+{% endblock %}

--- a/app/views/match/v1/match-design-history.html
+++ b/app/views/match/v1/match-design-history.html
@@ -1,0 +1,98 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Home" %}
+
+{% block content %}
+
+<div class="govuk-width-container">
+
+	<main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+	  <div class="govuk-grid-row">
+	  <div class="govuk-grid-column-full">
+  
+		<h1 class="govuk-heading-l"> 
+		  Match
+		</h1>
+  
+		<p class="govuk-body-l"> Match description</p>
+  
+	  <!-- <details class="govuk-details" data-module="govuk-details">
+		  <summary class="govuk-details__summary">
+			<span class="govuk-details__summary-text">
+			  User research, content docs and flow diagrams.
+			</span>
+		  </summary>
+		  <div class="govuk-details__text">
+			<p class="govuk-body govuk-!-margin-bottom-2">All links open in a new browser window or tab.</p>
+			<p class="govuk-body govuk-!-margin-bottom-2">User research:</p>
+			<ul class="govuk-list govuk-list--bullet">
+			  <li><a href="#" target="_blank" class="govuk-link govuk-link--no-visited-state">UR</a></li>
+			</ul>
+	  
+			<p class="govuk-body govuk-!-margin-bottom-2">Copydecks:</p>
+			<ul class="govuk-list govuk-list--bullet">
+			  <li><a href="https://docs.google.com/spreadsheets/d/1zrVbAQ6E5Pae9wjB4_rOt-aJs5Xe3kXQP4tV8ZpGgAM/edit#gid=206032704" target="_blank" class="govuk-link govuk-link--no-visited-state">View the first content document </a> </li>
+			  <li><a href="https://docs.google.com/spreadsheets/d/1FlLYdrceeCtI4rnabRoJgzxAUqSOGzLpCtJTcLC5vnE/edit#gid=1971658364" target="_blank" class="govuk-link govuk-link--no-visited-state">View the second content document </a>
+			  </li>
+			</ul>
+		  </details> --> 
+	  
+  
+	  <table class="govuk-table">
+	  <caption class="govuk-table__caption govuk-caption-xl">Prototype versions</caption>
+	  <thead class="govuk-table__head">
+		<tr class="govuk-table__row">
+		  <th scope="col" class="govuk-table__header" width="15%">Version</th>
+		  <th scope="col" class="govuk-table__header" width="15%">Status</th>
+		  <th scope="col" class="govuk-table__header" width="55%">What changed</th>
+		  <th scope="col" class="govuk-table__header" width="15%">Links to UR and other assets</th>
+		</tr>
+	  </thead>
+
+	  <tbody class="govuk-table__body">
+		<!--  version 18 -->
+		<tr class="govuk-table__row">
+		  <td class="govuk-table__cell">
+			<a href="/find/index.html" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Version 2</a>
+		  </td>
+		  <td class="govuk-table__cell">
+			<strong class="govuk-tag govuk-tag--grey">
+				Pending
+			  </strong>
+		  </td>
+		  <td class="govuk-table__cell">
+
+		  </td>
+		  <td class="govuk-table__cell">
+			<p> </p>
+		  </td>
+		</tr>
+
+		<tbody class="govuk-table__body">
+			<!--  version 18 -->
+			<tr class="govuk-table__row">
+			  <td class="govuk-table__cell">
+				<a href="#" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Version 1</a>
+			  </td>
+			  <td class="govuk-table__cell">
+				<span class="govuk-tag">
+				  STATUS
+				</span>
+			  </td>
+			  <td class="govuk-table__cell">
+				<p>Example content</p>
+			  </td>
+			  <td class="govuk-table__cell">
+				
+			  </td>
+			</tr>
+ 
+	  </tbody>
+	  </table>
+	  </div>
+	  </div>
+  
+	</main>
+  </div>
+
+{% endblock %}

--- a/app/views/match/v1/match-design-history.html
+++ b/app/views/match/v1/match-design-history.html
@@ -37,6 +37,7 @@
 			</ul>
 		  </details> --> 
 	  
+		 
   
 	  <table class="govuk-table">
 	  <caption class="govuk-table__caption govuk-caption-xl">Prototype versions</caption>
@@ -53,7 +54,7 @@
 		<!--  version 18 -->
 		<tr class="govuk-table__row">
 		  <td class="govuk-table__cell">
-			<a href="/find/index.html" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Version 2</a>
+			<a href="/match/v1/group-list" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Version 1</a>
 		  </td>
 		  <td class="govuk-table__cell">
 			<strong class="govuk-tag govuk-tag--grey">
@@ -67,26 +68,6 @@
 			<p> </p>
 		  </td>
 		</tr>
-
-		<tbody class="govuk-table__body">
-			<!--  version 18 -->
-			<tr class="govuk-table__row">
-			  <td class="govuk-table__cell">
-				<a href="#" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold">Version 1</a>
-			  </td>
-			  <td class="govuk-table__cell">
-				<span class="govuk-tag">
-				  STATUS
-				</span>
-			  </td>
-			  <td class="govuk-table__cell">
-				<p>Example content</p>
-			  </td>
-			  <td class="govuk-table__cell">
-				
-			  </td>
-			</tr>
- 
 	  </tbody>
 	  </table>
 	  </div>

--- a/app/views/match/v1/person-dashboard/person-dashboard.html
+++ b/app/views/match/v1/person-dashboard/person-dashboard.html
@@ -1,0 +1,148 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Home" %}
+
+{% block content %}
+
+	<section class="key-details-bar" aria-label="Key details">
+		<div class="key-details-bar__key-details">
+		<div class="key-details-bar__top-block">
+			<span class="govuk-visually-hidden">Name:</span>
+			<span class="key-details-bar__name">Del Hatton</span>
+		</div>
+		<div class="key-details-bar__bottom-block govuk-!-padding-top-0">
+			<span class="govuk-body govuk-!-margin-right-4 nav-border">Prison number: D0168KE</span> 
+			<span class="govuk-body govuk-!-margin-right-6">Current prison: HMP Erlestoke</span>
+		</div>
+		</div>
+	</section>
+
+
+
+	<div class="govuk-width-container ">
+			
+		<div class="govuk-!-margin-top-2">
+			<a href="group-information.html" class="govuk-back-link govuk-!-margin-bottom-0">Back to my referrals</a>
+		</div> 
+		
+		<main class="govuk-main-wrapper " id="main-content" role="main">
+				
+		<div class="govuk-grid-row">
+			<div class="govuk-grid-column-full">
+				<div class="moj-page-header-actions">
+					<div class="moj-page-header-actions__title">
+						<h1 class="govuk-heading-l">Referral to Becoming New Me Plus (BNM+)</h1>
+					</div>
+					<div class="moj-page-header-actions__actions">
+						<div class="moj-button-menu">
+							<div class="moj-button-menu__wrapper">
+								<a class="govuk-button moj-button-menu__item govuk-button--warning moj-page-header-actions__actiong" href="withdraw-referral">Withdraw referral</a>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+
+	<div class="govuk-grid-row">
+		<div class="govuk-grid-column-full">
+			<nav class="moj-sub-navigation" aria-label="Sub navigation">
+				<ul class="moj-sub-navigation__list">
+					<li class="moj-sub-navigation__item">
+						<a class="moj-sub-navigation__link" href="person-status-history.html">Status history</a>
+					</li>
+					<li class="moj-sub-navigation__item">
+						<a class="moj-sub-navigation__link" aria-current="page" href="personal-details">Referral details</a>
+					</li>
+					<li class="moj-sub-navigation__item">
+						<a class="moj-sub-navigation__link" href="person-risks-and-needs.html">Risks and needs</a>
+					</li>
+				</ul>
+			</nav>
+			<h2 class="govuk-heading-m">Referral summary</h2>
+			<ul class="govuk-list">
+				<li><strong>Programme name:</strong> Becoming New Me Plus (BNM+)</li>
+				<li><strong>Programme strand:</strong> Intimate partner violence</li>
+				<li><strong>Programme location:</strong> HMP Erlestoke</li>
+			</ul>
+			<ul class="govuk-list">
+				<li><strong>Date referred:</strong> 11 June 2023</li>
+				<li><strong>Referrer name:</strong> Jordan Smith</li>
+				<li><strong>Referrer email address:</strong> <a href="mailto:interventions.erlestoke@justice.gov.uk" class="govuk-link">interventions.erlestoke@justice.gov.uk</a></li>
+				<li><strong>Referrer contact number:</strong> 01380 814250</li>
+			</ul>
+			<hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+		</div>
+	</div>
+	
+	<div class="govuk-grid-row">
+		<div class="govuk-grid-column-one-quarter">
+			<nav class="moj-side-navigation govuk-!-padding-top-0" aria-label="Side navigation">
+				<ul class="moj-side-navigation__list">
+					<li class="moj-side-navigation__item moj-side-navigation__item--active">
+						<a href="personal-details" aria-current="location">Personal details</a>
+					  </li>
+					  <li class="moj-side-navigation__item">
+						<a href="programme-history">Programme history</a>
+					  </li>
+					<li class="moj-side-navigation__item">
+						<a href="offence-history">Offence history</a>
+					  </li>
+					<li class="moj-side-navigation__item">
+						<a href="sentence-information">Sentence information</a>
+					  </li>
+					<li class="moj-side-navigation__item">
+						<a href="additional-information">Additional information</a>
+					  </li>
+				</ul>
+			</nav>
+		</div>
+		<div class="govuk-grid-column-three-quarters">
+			<div class="govuk-inset-text govuk-!-margin-top-0">Imported from Nomis on 1 August 2023, last updated on 4 January 2023</div>
+				<div class="govuk-summary-card">
+					<div class="govuk-summary-card__title-wrapper">
+						  <h2 class="govuk-summary-card__title">Personal details</h2>
+					</div>
+					<div class="govuk-summary-card__content">
+						<dl class="govuk-summary-list">
+							<div class="govuk-summary-list__row">
+								<dt class="govuk-summary-list__key">Name</dt>
+								<dd class="govuk-summary-list__value">Del Hatton</dd>
+							</div>
+							<div class="govuk-summary-list__row">
+								<dt class="govuk-summary-list__key">Prison number</dt>
+								<dd class="govuk-summary-list__value">D0168KE</dd>
+							</div>
+							<div class="govuk-summary-list__row">
+								<dt class="govuk-summary-list__key">Date of birth</dt>
+								<dd class="govuk-summary-list__value">5 July 1971</dd>
+							</div>
+							<div class="govuk-summary-list__row">
+								<dt class="govuk-summary-list__key">Ethnicity</dt>
+								<dd class="govuk-summary-list__value">White and Black African</dd>
+							</div>
+							<div class="govuk-summary-list__row">
+								<dt class="govuk-summary-list__key">Gender</dt>
+								<dd class="govuk-summary-list__value">Male</dd>
+							</div>
+							<!-- <div class="govuk-summary-list__row">
+								<dt class="govuk-summary-list__key">Religion or belief</dt>
+								<dd class="govuk-summary-list__value">Christian</dd>
+							</div> -->
+							<div class="govuk-summary-list__row">
+								<dt class="govuk-summary-list__key">Setting</dt>
+								<dd class="govuk-summary-list__value">Custody</dd>
+							</div>
+							<div class="govuk-summary-list__row">
+								<dt class="govuk-summary-list__key">Current prison</dt>
+								<dd class="govuk-summary-list__value">HMP Erlestoke</dd>
+							</div>
+						</dl>
+					</div>
+				 </div>
+			</div>
+		</div>
+	</main></div>
+	
+
+{% endblock %}

--- a/app/views/match/v1/person-dashboard/person-risks-and-needs.html
+++ b/app/views/match/v1/person-dashboard/person-risks-and-needs.html
@@ -1,0 +1,147 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Home" %}
+
+{% block content %}
+
+<section class="key-details-bar" aria-label="Key details">
+	<div class="key-details-bar__key-details">
+	  <div class="key-details-bar__top-block">
+		  <span class="govuk-visually-hidden">Name:</span>
+		  <span class="key-details-bar__name">Del Hatton</span>
+	  </div>
+	  <div class="key-details-bar__bottom-block govuk-!-padding-top-0">
+		  <span class="govuk-body govuk-!-margin-right-4 nav-border">Prison number: D0168KE</span> 
+		  <span class="govuk-body govuk-!-margin-right-6">Current prison: HMP Erlestoke</span>
+	  </div>
+	</div>
+</section>
+
+<div class="govuk-width-container ">
+        
+	<div class="govuk-!-margin-top-2">
+		<a href="group-information.html" class="govuk-back-link govuk-!-margin-bottom-0">Back to my referrals</a>
+	</div> 
+	
+			<main class="govuk-main-wrapper " id="main-content" role="main">
+			  
+	<div class="govuk-grid-row">
+		<div class="govuk-grid-column-full">
+			<div class="moj-page-header-actions">
+				<div class="moj-page-header-actions__title">
+					  <h1 class="govuk-heading-l">Referral to Becoming New Me Plus (BNM+)</h1>
+				</div>
+				<div class="moj-page-header-actions__actions">
+					  <div class="moj-button-menu">
+						<div class="moj-button-menu__wrapper">
+							
+							<a class="govuk-button moj-button-menu__item govuk-button--warning moj-page-header-actions__actiong" href="withdraw-referral">Withdraw referral</a>
+							
+						</div>
+					  </div>
+				</div>
+			 </div>
+		</div>
+	</div>
+	<div class="govuk-grid-row">
+		<div class="govuk-grid-column-full">
+			<nav class="moj-sub-navigation" aria-label="Sub navigation">
+				<ul class="moj-sub-navigation__list">
+					<li class="moj-sub-navigation__item">
+						<a class="moj-sub-navigation__link" href="person-status-history.html">Status history</a>
+					</li>
+					<li class="moj-sub-navigation__item">
+						<a class="moj-sub-navigation__link" href="person-dashboard.html">Referral details</a>
+					</li>
+					<li class="moj-sub-navigation__item">
+						<a class="moj-sub-navigation__link" aria-current="page" href="person-risks-and-needs.html">Risks and needs</a>
+					</li>
+				</ul>
+			</nav>
+			<h2 class="govuk-heading-m">Referral summary</h2>
+			<ul class="govuk-list">
+				<li><strong>Programme name:</strong> Becoming New Me Plus (BNM+)</li>
+				<li><strong>Programme strand:</strong> Intimate partner violence</li>
+				<li><strong>Programme location:</strong> HMP Erlestoke</li>
+			</ul>
+			<ul class="govuk-list">
+				<li><strong>Date referred:</strong> 11 June 2023</li>
+				<li><strong>Referrer name:</strong> Jordan Smith</li>
+				<li><strong>Referrer email address:</strong> <a href="mailto:interventions.erlestoke@justice.gov.uk" class="govuk-link">interventions.erlestoke@justice.gov.uk</a></li>
+				<li><strong>Referrer contact number:</strong> 01380 814250</li>
+			</ul>
+			<hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+		</div>
+	</div>
+	
+	<div class="govuk-grid-row">
+		<div class="govuk-grid-column-one-quarter">
+			<nav class="moj-side-navigation govuk-!-padding-top-0" aria-label="Side navigation">
+				<ul class="moj-side-navigation__list">
+					<li class="moj-side-navigation__item moj-side-navigation__item--active">
+						<a href="personal-details" aria-current="location">Personal details</a>
+					  </li>
+					  <li class="moj-side-navigation__item">
+						<a href="programme-history">Programme history</a>
+					  </li>
+					<li class="moj-side-navigation__item">
+						<a href="offence-history">Offence history</a>
+					  </li>
+					<li class="moj-side-navigation__item">
+						<a href="sentence-information">Sentence information</a>
+					  </li>
+					<li class="moj-side-navigation__item">
+						<a href="additional-information">Additional information</a>
+					  </li>
+				</ul>
+			</nav>
+		</div>
+		<div class="govuk-grid-column-three-quarters">
+			<div class="govuk-inset-text govuk-!-margin-top-0">Imported from Nomis on 1 August 2023, last updated on 4 January 2023</div>
+				<div class="govuk-summary-card">
+					<div class="govuk-summary-card__title-wrapper">
+						  <h2 class="govuk-summary-card__title">Personal details</h2>
+					</div>
+					<div class="govuk-summary-card__content">
+						<dl class="govuk-summary-list">
+							<div class="govuk-summary-list__row">
+								<dt class="govuk-summary-list__key">Name</dt>
+								<dd class="govuk-summary-list__value">Del Hatton</dd>
+							</div>
+							<div class="govuk-summary-list__row">
+								<dt class="govuk-summary-list__key">Prison number</dt>
+								<dd class="govuk-summary-list__value">D0168KE</dd>
+							</div>
+							<div class="govuk-summary-list__row">
+								<dt class="govuk-summary-list__key">Date of birth</dt>
+								<dd class="govuk-summary-list__value">5 July 1971</dd>
+							</div>
+							<div class="govuk-summary-list__row">
+								<dt class="govuk-summary-list__key">Ethnicity</dt>
+								<dd class="govuk-summary-list__value">White and Black African</dd>
+							</div>
+							<div class="govuk-summary-list__row">
+								<dt class="govuk-summary-list__key">Gender</dt>
+								<dd class="govuk-summary-list__value">Male</dd>
+							</div>
+							<!-- <div class="govuk-summary-list__row">
+								<dt class="govuk-summary-list__key">Religion or belief</dt>
+								<dd class="govuk-summary-list__value">Christian</dd>
+							</div> -->
+							<div class="govuk-summary-list__row">
+								<dt class="govuk-summary-list__key">Setting</dt>
+								<dd class="govuk-summary-list__value">Custody</dd>
+							</div>
+							<div class="govuk-summary-list__row">
+								<dt class="govuk-summary-list__key">Current prison</dt>
+								<dd class="govuk-summary-list__value">HMP Erlestoke</dd>
+							</div>
+						</dl>
+					</div>
+				 </div>
+			</div>
+		</div>
+	</main></div>
+	
+
+{% endblock %}

--- a/app/views/match/v1/person-dashboard/person-status-history.html
+++ b/app/views/match/v1/person-dashboard/person-status-history.html
@@ -1,0 +1,114 @@
+{% extends "layouts/main.html" %}
+
+{% set pageName="Home" %}
+
+
+{% block content %}
+
+<section class="key-details-bar" aria-label="Key details">
+	<div class="key-details-bar__key-details">
+	  <div class="key-details-bar__top-block">
+		  <span class="govuk-visually-hidden">Name:</span>
+		  <span class="key-details-bar__name">Del Hatton</span>
+	  </div>
+	  <div class="key-details-bar__bottom-block govuk-!-padding-top-0">
+		  <span class="govuk-body govuk-!-margin-right-4 nav-border">Prison number: D0168KE</span> 
+		  <span class="govuk-body govuk-!-margin-right-6">Current prison: HMP Erlestoke</span>
+	  </div>
+	</div>
+</section>
+
+<div class="govuk-width-container">
+
+	<div class="govuk-!-margin-top-2">
+		<a href="group-information.html" class="govuk-back-link govuk-!-margin-bottom-0">Back to my referrals</a>
+	</div> 
+	
+	
+			<main class="govuk-main-wrapper " id="main-content" role="main">
+			  
+	<div class="govuk-grid-row">
+		<div class="govuk-grid-column-full">
+			<div class="moj-page-header-actions">
+				<div class="moj-page-header-actions__title">
+					  <h1 class="govuk-heading-l">Referral to Becoming New Me Plus (BNM+)</h1>
+				</div>
+				<div class="moj-page-header-actions__actions">
+					  <div class="moj-button-menu">
+						<div class="moj-button-menu__wrapper">
+							
+							<a class="govuk-button moj-button-menu__item govuk-button--warning moj-page-header-actions__actiong" href="withdraw-referral">Withdraw referral</a>
+							
+						</div>
+					  </div>
+				</div>
+			 </div>
+		</div>
+	</div>
+	<div class="govuk-grid-row">
+		<div class="govuk-grid-column-full">
+			<nav class="moj-sub-navigation" aria-label="Sub navigation">
+				<ul class="moj-sub-navigation__list">
+					<li class="moj-sub-navigation__item">
+						<a class="moj-sub-navigation__link" aria-current="page" href="person-status-history.html">Status history</a>
+					</li>
+					<li class="moj-sub-navigation__item">
+						<a class="moj-sub-navigation__link" href="person-dashboard.html">Referral details</a>
+					</li>
+					<li class="moj-sub-navigation__item">
+						<a class="moj-sub-navigation__link" href="perso">Risks and needs</a>
+					</li>
+				</ul>
+			</nav>
+		
+			<div class="govuk-grid-column-two-thirds">
+
+				<div class="govuk-form-group">
+					<h1 class="govuk-label-wrapper">
+					  <label class="govuk-label govuk-label--m" for="more-detail">
+						Add a note
+					  </label>
+					</h1>
+					<textarea class="govuk-textarea" id="more-detail" name="moreDetail" rows="5" aria-describedby="more-detail-hint"></textarea>
+					<div class="govuk-button-group">
+						<a class="govuk-button" href="#">Update</a>
+					</div>
+				  </div>
+
+				<h2 class="govuk-heading-m">Status history</h2>
+				
+				<p class="govuk-body">View progress and update the status of a referral.</p>
+			
+				<div class="moj-timeline">
+					<div class="moj-timeline__item">
+						<div class="moj-timeline__header">
+							<h2 class="moj-timeline__title">Status update</h2>
+							<p class="moj-timeline__byline">by Carol Duffy</p>
+						  </div>
+						  <p class="moj-timeline__date">
+							<time datetime="2023-07-03T14:09:00.000Z">3 July 2023 at 2:09pm</time>
+						  </p>
+						  <div class="moj-timeline__description">
+							<strong class="govuk-tag govuk-tag--orange">Awaiting assessment</strong>
+						  </div>
+					</div>
+					<div class="moj-timeline__item">
+						<div class="moj-timeline__header">
+							<h2 class="moj-timeline__title">Referral submitted</h2>
+							<p class="moj-timeline__byline">by Jordan Smith</p>
+						  </div>
+						  <p class="moj-timeline__date">
+							<time datetime="2023-06-28T10:00:00.000Z">28 June 2023 at 10:00am</time>
+						  </p>
+						  <div class="moj-timeline__description">
+							<strong class="govuk-tag govuk-tag--red">Referral submitted</strong>
+						  </div>
+					</div> 
+				</div>
+				
+			</div>
+		</div>
+	</main></div>
+	
+
+{% endblock %}


### PR DESCRIPTION
We've created initial screens for the matching prototype, based off the Activities Management prototype. 

**New screens include**

- Group list - a list of all groups and programmes that have been created 
- Group information - further information about the people allocated to a group 
- Create a group journey 